### PR TITLE
Add redundant authors information to display these in the standard latex template

### DIFF
--- a/paper.md
+++ b/paper.md
@@ -6,12 +6,21 @@ tags:
   - molecular biology
   - protein evolution
   - data visualization
+author:
+  - Sarah K. Hilton*
+  - John Huddleston*
+  - Allison Black
+  - Khrystyna North
+  - Adam S. Dingens
+  - Trevor Bedford
+  - Jesse D. Bloom
 authors:
   - name: Sarah K. Hilton*
     affiliation: "1, 2"
     orcid: 0000-0001-9278-3644
   - name: John Huddleston*
     affiliation: "3, 4"
+    orcid: 0000-0002-4250-2063
   - name: Allison Black
     affiliation: "3, 5"
   - name: Khrystyna North


### PR DESCRIPTION
This ~needs to be~ has been tested through the JOSS Whedon compiler to make sure the
redundant authors don't break the JOSS rendering, and this does create a nicer
default PDF with the default latex template.

Also, this commit adds my ORCID.